### PR TITLE
added memory offset option

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -8,8 +8,10 @@ static constexpr uint8_t source_i2c_address_for_program =
 static constexpr uint32_t eeprom_not_programmed =
     0xFFFFFFFF; // default value in eeprom when not programmed
 
-static constexpr uint8_t timestamp_application_byte_offset = 20;
-static constexpr uint8_t application_length_byte_offset = 32;
-static constexpr uint8_t application_byte_offset = 34;
-static constexpr uint8_t application_start_address_byte_offset = 36;
-static constexpr uint8_t application_crc_expected_index = 28;
+static constexpr uint16_t eeprom_address_offset = 0x0000;
+
+static constexpr uint16_t timestamp_application_byte_offset = 20 + eeprom_address_offset;
+static constexpr uint16_t application_length_byte_offset = 32 + eeprom_address_offset;
+static constexpr uint16_t application_byte_offset = 34 + eeprom_address_offset;
+static constexpr uint16_t application_start_address_byte_offset = 36 + eeprom_address_offset;
+static constexpr uint16_t application_crc_expected_index = 28 + eeprom_address_offset;

--- a/src/converter.bat
+++ b/src/converter.bat
@@ -1,0 +1,4 @@
+wsl make
+pause
+avrdude -c usbtiny -p m328p -U flash:w:miniboot.hex
+pause

--- a/src/converter.bat
+++ b/src/converter.bat
@@ -1,4 +1,0 @@
-wsl make
-pause
-avrdude -c usbtiny -p m328p -U flash:w:miniboot.hex
-pause


### PR DESCRIPTION
Allows you to store two different programs at two different locations in memory for two different microcontrollers!  Simply upload the program to the EEPROM at an offset, and for one of the two microcontrollers burn the bootloader with the eeprom_address_offset variable changed.