### PR TITLE
Fix post summary when no PR was created

### DIFF
--- a/scripts/post_summary.sh
+++ b/scripts/post_summary.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -x #echo on
 
+[[ -z "$TRAVIS_PULL_REQUEST" ]] && { echo "Change is not a PR, nowhere to push summary to. Exiting." ; exit 0; }
+
 make_log=$1
 
 header="\`CI Auto Message\`\n---\n"


### PR DESCRIPTION
Fixes #16, which occurs when a change triggers a CI job but no PR was created. So there is no endpoint for `curl` to post the summary to.