### PR TITLE
Optimizing flash footprint

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -11,7 +11,7 @@ static constexpr uint32_t eeprom_not_programmed =
 static constexpr uint16_t eeprom_address_offset = 0x0000;
 
 static constexpr uint16_t timestamp_application_byte_offset = 20 + eeprom_address_offset;
+static constexpr uint16_t application_crc_expected_offset = 28 + eeprom_address_offset;
 static constexpr uint16_t application_length_byte_offset = 32 + eeprom_address_offset;
 static constexpr uint16_t application_byte_offset = 34 + eeprom_address_offset;
 static constexpr uint16_t application_start_address_byte_offset = 36 + eeprom_address_offset;
-static constexpr uint16_t application_crc_expected_index = 28 + eeprom_address_offset;

--- a/src/i2c_communication.h
+++ b/src/i2c_communication.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "I2C-master-lib/i2c_master.h"
+#include "config.h"
 
-static inline uint8_t readByte(const uint8_t source_address,
-                               const uint16_t register_address) {
+static inline uint8_t readByte(const uint16_t register_address) {
   uint8_t data = 0xFF;
-  uint8_t write_source_address = source_address << 1;
+  uint8_t write_source_address = source_i2c_address_for_program << 1;
   i2c_start(write_source_address);
   i2c_write(register_address >> 8);
   i2c_write(register_address);
@@ -18,10 +18,9 @@ static inline uint8_t readByte(const uint8_t source_address,
   return data;
 }
 
-static inline uint16_t getWordFromSource(const uint8_t i2c_address,
-                                         const uint16_t data_address) {
-  uint16_t result = static_cast<uint16_t>(readByte(i2c_address, data_address))
+static inline uint16_t getWordFromSource(const uint16_t data_address) {
+  uint16_t result = static_cast<uint16_t>(readByte(data_address))
                     << 8;
-  result |= static_cast<uint16_t>(readByte(i2c_address, data_address + 1));
+  result |= static_cast<uint16_t>(readByte(data_address + 1));
   return result;
 }

--- a/src/io.h
+++ b/src/io.h
@@ -12,7 +12,7 @@
 
 #define LED_INIT()                                                             \
   LED_OFF();                                                                   \
-  OUTPORT(LED_PORT_NAME) = (1 << (LED_PIN))
+  OUTPORT(LED_PORT_NAME) |= (1 << (LED_PIN))
 
 #define RESET_VECTOR 0x0000
 #define RESET_VECTOR_ARGUMENT_ADDRESS 0x0002

--- a/src/miniboot.c
+++ b/src/miniboot.c
@@ -68,10 +68,10 @@ static inline bool isCrcOk() {
       LED_TOGGLE();
   }
 
-  uint32_t expected_crc = static_cast<uint32_t>(getWordFromSource(application_crc_expected_index))
+  uint32_t expected_crc = static_cast<uint32_t>(getWordFromSource(application_crc_expected_offset))
                           << 16;
   expected_crc |= static_cast<uint32_t>(
-      getWordFromSource(application_crc_expected_index + 2));
+    getWordFromSource(application_crc_expected_offset + 2));
 
   if (crc == expected_crc) {
     status = true;


### PR DESCRIPTION
After pondering on issue #25, I was wondering if there _was_ any optimizations to be done. 

After doing some experimenting, I found that we could save some flash space by removing un-needed passes of the I2C slave's address, as it remains constant throughout the whole program.

And even if it is changed during runtime, the program is still able to function properly, (an example of which I will post in the aforementioned issue later on).

My very unscientific tests showed that the original gave a total size of `17767`

And after these changes, it lowered to `17728`

I am running Manjaro Linux, avr-g++ version 9.2.0