### PR TITLE
Bazelize dependency to avr-bootloader-common

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,3 @@
 [submodule "utils/3rdparty/esp32_eeprom_flasher"]
 	path = utils/3rdparty/esp32_eeprom_flasher
 	url = https://github.com/nullstalgia/esp32_eeprom_flasher
-[submodule "src/avr-bootloader-common"]
-	path = src/avr-bootloader-common
-	url = https://github.com/mihaigalos/avr-bootloader-common.git
-    branch = main
-    # using commit e88723e071d2f198daab7e1fcbe6db6176d9cc97 from  mihaigalos/avr-bootloader-common
-    # subsequent commits contain a bazel BUILD and WORKSPACE file which break bazel compilation
-    # on miniboot and require submodules be modeled at bazel level instead of git submodule level.

--- a/BUILD
+++ b/BUILD
@@ -71,6 +71,7 @@ cc_binary(
     }),
     deps = [
         ":bootloader_h",
+        "@avr-bootloader-common",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,13 @@ git_repository(
 )
 
 git_repository(
+    name = "avr-bootloader-common",
+    commit = "b9a639de3f4a731a5044026fd1093c8d25971685",
+    remote = "https://github.com/mihaigalos/avr-bootloader-common",
+    shallow_since = "1611476679 +0100",
+)
+
+git_repository(
     name = "avr_tools",
     commit = "997c1096f95a12385addc9ecce7a6aae33ae933b",
     remote = "https://github.com/mihaigalos/bazel-avr-tools",


### PR DESCRIPTION
Currently, `avr-bootloader-common` is a submodule dependency.
This PR makes it now a `bazel` dependency which will be auto-fetched when building the `hex` targets.